### PR TITLE
Remove state handling duties from the base SeaNet driver

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -67,21 +67,13 @@ int main(int argc, char** argv)
     driver.openSerial(argv[1],baudrate);
     base::samples::RigidBodyState rbs;
     driver.configure(config,1000);
-    driver.start();
-    sea_net::PacketType packet_type = sea_net::mtNull;
     base::samples::SonarBeam sonar_beam;
-    while(1){
-        packet_type = driver.readPacket(1000);
-        switch(packet_type){
-        case sea_net::mtHeadData:
-            {
-                 driver.decodeSonarBeam(sonar_beam);
-                 udp.sendSonarBeam(sonar_beam);
-                 break;
-            }
-        default:
-            break;
-        }
+    driver.requestData();
+    while(1) {
+        driver.receiveData(1000);
+        driver.requestData();
+        driver.decodeSonarBeam(sonar_beam);
+        udp.sendSonarBeam(sonar_beam);
     }
     return 0;
 }

--- a/src/SeaNet.cpp
+++ b/src/SeaNet.cpp
@@ -138,6 +138,11 @@ void SeaNet::requestData()
     writePacket(&packet[0],packet.size(), getWriteTimeout());
 }
 
+bool SeaNet::hasPendingData() const
+{
+    return has_pending_data;
+}
+
 void SeaNet::receiveData(int timeout)
 {
     LOG_DEBUG_S << "waiting for a mtHeadData packet" ;

--- a/src/SeaNet.cpp
+++ b/src/SeaNet.cpp
@@ -71,12 +71,17 @@ void SeaNet::waitForPacket(PacketType type,int timeout)
 
 bool SeaNet::isFullDublex(int timeout)
 {
+    return isFullDuplex(timeout);
+}
+
+bool SeaNet::isFullDuplex(int timeout)
+{
     std::vector<uint8_t> packet = SeaNetPacket::createPaket(device_type,mtSendBBUser);
     writePacket(&packet[0],packet.size());
     waitForPacket(mtBBUserData,timeout);
     BBUserData settings;
     sea_net_packet.decodeBBUserData(settings);
-    return settings.full_dublex;
+    return settings.full_duplex;
 }
 
 SeaNetPacket* SeaNet::getSeaNetPacket()

--- a/src/SeaNet.cpp
+++ b/src/SeaNet.cpp
@@ -19,6 +19,7 @@ SeaNet::~SeaNet()
 void SeaNet::openSerial(std::string const& port, int baudrate)
 {
     LOG_DEBUG_S <<"opening serial port: "<<  port << " with baudrate: " << baudrate ;
+    has_pending_data = false;
     ::iodrivers_base::Driver::openSerial(port,baudrate);
 }
 
@@ -26,6 +27,12 @@ void SeaNet::openURI(std::string const& uri)
 {
     has_pending_data = false;
     return iodrivers_base::Driver::openURI(uri);
+}
+
+void SeaNet::clear()
+{
+    has_pending_data = false;
+    return iodrivers_base::Driver::clear();
 }
 
 void SeaNet::reboot(int timeout)

--- a/src/SeaNet.cpp
+++ b/src/SeaNet.cpp
@@ -8,7 +8,7 @@ namespace sea_net{
 
 SeaNet::SeaNet(DeviceType type): 
   iodrivers_base::Driver(SEA_NET_MAX_PACKET_SIZE,false),
-  device_type(type),bstart(false)
+  device_type(type),has_pending_data(false)
 {
 }
 
@@ -22,17 +22,10 @@ void SeaNet::openSerial(std::string const& port, int baudrate)
     ::iodrivers_base::Driver::openSerial(port,baudrate);
 }
 
-void SeaNet::start()
+void SeaNet::openURI(std::string const& uri)
 {
-    clear();
-    bstart = true;
-    writeSendData(WRITE_TIMEOUT);
-    //TODO check if configure was called before
-}
-
-void SeaNet::stop()
-{
-    bstart = false;
+    has_pending_data = false;
+    return iodrivers_base::Driver::openURI(uri);
 }
 
 void SeaNet::reboot(int timeout)
@@ -78,66 +71,46 @@ bool SeaNet::isFullDuplex(int timeout)
     return settings.full_duplex;
 }
 
-SeaNetPacket* SeaNet::getSeaNetPacket()
+SeaNetPacket const& SeaNet::getSeaNetPacket() const
 {
-    return &sea_net_packet;
+    return sea_net_packet;
 }
 
 sea_net::PacketType SeaNet::readPacket(int timeout)
 {
-    iodrivers_base::Timeout time_out(timeout);
-    while(!time_out.elapsed())
-    {
-        uint8_t* buffer = sea_net_packet.getPacketPtr();
-        size_t size = iodrivers_base::Driver::readPacket(buffer,SEA_NET_MAX_PACKET_SIZE,time_out.timeLeft());
-        sea_net_packet.setSize(size);
-        if(!sea_net_packet.validate())
-            throw std::runtime_error("extractPacket has extracted an invalid package!");  //this should never happen
-        
-        //trigger head again to get the next beam
-        PacketType type = sea_net_packet.getPacketType();
-        switch(type)
-        {
-            case mtHeadData:
-                if(bstart)
-                    writeSendData(time_out.timeLeft());
-                break;
-            case mtAlive:
-                break;
-            default:
-                break;
-        }
-        
-        LOG_DEBUG_S << "read packet of type: "<< type ;
-        return type;
-    }
-    return mtNull;
+    uint8_t* buffer = sea_net_packet.getPacketPtr();
+    size_t size = iodrivers_base::Driver::readPacket(
+            buffer,
+            SEA_NET_MAX_PACKET_SIZE,
+            base::Time::fromMilliseconds(timeout));
+    sea_net_packet.setSize(size);
+    if(!sea_net_packet.validate())
+        throw std::runtime_error("extractPacket has extracted an invalid package!");  //this should never happen
+    LOG_DEBUG_S << "read packet of type: "<< sea_net_packet.getPacketType() ;
+    if (sea_net_packet.getPacketType() == mtHeadData)
+        has_pending_data = false;
+
+    return sea_net_packet.getPacketType();
 }
 
 void SeaNet::writeHeadCommand(HeadCommand &head_config, int timeout)
 {
-    AliveData alive_data;
-    bool received_alive = false;
-    bool was_started = bstart;
+    if (has_pending_data)
+        throw std::runtime_error("requestData() called and the corresponding receiveData() has not been called");
 
     iodrivers_base::Timeout time_out(timeout);
-    std::vector<uint8_t> packet = SeaNetPacket::createPaket(device_type,
-                                                           mtHeadCommand,
-                                                           (uint8_t*)&head_config,
-                                                            sizeof(head_config));
-    stop();
-    //we have to wait until the device is no longer sending HeadData
-    try
-    {
-        while(true) waitForPacket(mtHeadData,300); 
-    }
-    catch(std::runtime_error e)
-    {}
+    std::vector<uint8_t> packet =
+        SeaNetPacket::createPaket(device_type,
+                mtHeadCommand,
+                (uint8_t*)&head_config,
+                sizeof(head_config));
 
     LOG_DEBUG_S <<"Sent mtHeadCommand packet" ;
-    writePacket(&packet[0],packet.size());
+    writePacket(&packet[0],packet.size(),time_out.timeLeft());
 
     //wait for an alive packet to check if the sonar is configured
+    AliveData alive_data;
+    bool received_alive = false;
     while(!alive_data.ready && alive_data.no_config && !alive_data.config_send)
     {
         try
@@ -155,34 +128,20 @@ void SeaNet::writeHeadCommand(HeadCommand &head_config, int timeout)
         received_alive = true;
         sea_net_packet.decodeAliveData(alive_data);
     }
-    if(was_started)
-    {
-        start();
-        PacketType packet_type = mtNull;
-        while(packet_type != sea_net::mtHeadData)
-        {
-            packet_type = readPacket(time_out.timeLeft());
-            switch(packet_type)
-            {
-            case sea_net::mtAlive:
-                //send start packet again 
-                //this is necessary because 
-                //the sonar is not accepting mtSendData
-                //after configuration for some milliseconds 
-                writeSendData(time_out.timeLeft());             
-                break;
-            default:
-                break;
-            }
-        }
-    }
 }
 
-void SeaNet::writeSendData(int timeout) 
+void SeaNet::requestData() 
 {
     LOG_DEBUG_S << "write mtSendData packet" ;
+    has_pending_data = true;
     std::vector<uint8_t> packet = SeaNetPacket::createSendDataPaket(device_type);
-    writePacket(&packet[0],packet.size());
+    writePacket(&packet[0],packet.size(), getWriteTimeout());
+}
+
+void SeaNet::receiveData(int timeout)
+{
+    LOG_DEBUG_S << "waiting for a mtHeadData packet" ;
+    waitForPacket(mtHeadData, timeout);
 }
 
 int SeaNet::extractPacket(uint8_t const* buffer, size_t buffer_size) const
@@ -195,6 +154,5 @@ void SeaNet::setWriteTimeout(uint32_t timeout)
 {
     Driver::setWriteTimeout(base::Time::fromMicroseconds(timeout*1000));
 }
-
 
 }

--- a/src/SeaNet.cpp
+++ b/src/SeaNet.cpp
@@ -22,12 +22,6 @@ void SeaNet::openSerial(std::string const& port, int baudrate)
     ::iodrivers_base::Driver::openSerial(port,baudrate);
 }
 
-void SeaNet::close()
-{
-    LOG_DEBUG_S <<"closing serial port: " ;
-    Driver::close();
-}
-
 void SeaNet::start()
 {
     clear();

--- a/src/SeaNet.hpp
+++ b/src/SeaNet.hpp
@@ -24,8 +24,6 @@ public:
          *
          * Throws UnixError on error */
         void openSerial(std::string const& port, int baudrate=115200);
-        void close();
-
         /** Clears the input buffer and triggers the device to send 
          *  mtHeadData 
          *

--- a/src/SeaNet.hpp
+++ b/src/SeaNet.hpp
@@ -72,6 +72,15 @@ public:
          */
         void requestData();
 
+        /** Checks whether data has been requested but not received yet
+         *
+         * Some operations (e.g. configure()) cannot be called if it is the
+         * case. For these operations, if you don't know whether data has been
+         * requested, you must check whether hasPendingData() returns true and
+         * call receiveData() first.
+         */
+        bool hasPendingData() const;
+
         /** Wait for the beam data requested by requestData to be received
          *
          * @param timeout the timeout in milliseconds

--- a/src/SeaNet.hpp
+++ b/src/SeaNet.hpp
@@ -51,21 +51,7 @@ public:
         void getVersion(VersionData &version, int timeout);
 
         bool isFullDublex(int timeout);
-
-        ///
-        //decode functions 
-        //
-        /** gives a reference to the raw data read by readPacket */
-        void decodeRawData(const uint8_t* &buffer, size_t &size);
         
-
-        /** extracts the payload from a mtAux package 
-         *
-         *  call this function if readPacket returns mtAuxData */  
-        void decodeAuxData(std::vector<uint8_t> &data);
-
-        void decodeAliveData(AliveData &data);
-
         void setWriteTimeout(uint32_t timeout);
 
 protected:

--- a/src/SeaNet.hpp
+++ b/src/SeaNet.hpp
@@ -50,6 +50,12 @@ public:
          *  call this function if readPacket returns mtVersionData */  
         void getVersion(VersionData &version, int timeout);
 
+        /** Returns if the remote device is configured as full duplex or half
+         * duplex
+         */
+        bool isFullDuplex(int timeout);
+
+        /** @deprecated use isFullDuplex instead */
         bool isFullDublex(int timeout);
         
         void setWriteTimeout(uint32_t timeout);

--- a/src/SeaNet.hpp
+++ b/src/SeaNet.hpp
@@ -9,7 +9,7 @@ namespace sea_net {
 class SeaNetPacket;
 class HeadConfigPacket;
 
-class SeaNet : protected ::iodrivers_base::Driver
+class SeaNet : public ::iodrivers_base::Driver
 {
 public:
         /** Base class for RS232 SeaNet devices
@@ -24,21 +24,23 @@ public:
          *
          * Throws UnixError on error */
         void openSerial(std::string const& port, int baudrate=115200);
-        /** Clears the input buffer and triggers the device to send 
-         *  mtHeadData 
-         *
-         * Throws UnixError on error */
-        void start();
-        void stop();
+
+        /** Overloaded from iodrivers_base::Driver */
+        void openURI(std::string const& uri);
 
         /** Reboots the Device and waits for a mtAlive package 
          *  be careful this takes a while and even if you receive mtAlives
          *  the device my be in a state where it does not accept mtHeadCommands */
         void reboot(int timeout);
 
-        /** Reads one packat from the input buffer and returns its type.
-         *  Use getAuxData, getVersion ... depending on the returned type
-         *  to get the content of the package */
+        /** Reads one packat from I/O and returns the packet type
+         *
+         * The packet's content can be retrieved by the SeaNetPacket API on the
+         * value returned by getSeaNetPacket
+         *
+         * @param timeout the timeout in milliseconds
+         * @return the packet type
+         */
         PacketType readPacket(int timeout);
 
         void waitForPacket(PacketType type, int timeout);
@@ -58,16 +60,32 @@ public:
         
         void setWriteTimeout(uint32_t timeout);
 
+        /** Returns the structure holding the last received packet */
+        SeaNetPacket const& getSeaNetPacket() const;
+
+        /** Request the sonar to acquire one beam
+         *
+         * Calling this method will fail until the corresponding data packet has
+         * been received.
+         *
+         * The timeout is the default write timeout
+         */
+        void requestData();
+
+        /** Wait for the beam data requested by requestData to be received
+         *
+         * @param timeout the timeout in milliseconds
+         */
+        void receiveData(int timeout);
+
 protected:
-        void writeSendData(int timeout);
         void writeHeadCommand(HeadCommand &hc, int timeout);
         virtual int extractPacket(uint8_t const* buffer, size_t buffer_size) const;
-        SeaNetPacket* getSeaNetPacket();
 
 protected:
         SeaNetPacket sea_net_packet;
         DeviceType device_type;
-        bool bstart;
+        bool has_pending_data;
 }; };
 #endif
 

--- a/src/SeaNet.hpp
+++ b/src/SeaNet.hpp
@@ -28,6 +28,9 @@ public:
         /** Overloaded from iodrivers_base::Driver */
         void openURI(std::string const& uri);
 
+        /** Overloaded from iodrivers_base::Driver */
+        void clear();
+
         /** Reboots the Device and waits for a mtAlive package 
          *  be careful this takes a while and even if you receive mtAlives
          *  the device my be in a state where it does not accept mtHeadCommands */

--- a/src/SeaNetProfiling.cpp
+++ b/src/SeaNetProfiling.cpp
@@ -35,38 +35,34 @@ Profiling::~Profiling()
     delete timestamp_estimator;
 }
 
+struct ProfilingHeadCommand
+{
+    uint8_t V3B_params; uint16_t head_control; uint8_t head_type;
+    uint32_t txn_ch1; uint32_t txn_ch2; uint32_t rxn_ch1; uint32_t rxn_ch2;
+    uint16_t pulse_length; uint16_t range_scale; uint16_t left_limit;
+    uint16_t right_limit; uint8_t ad_threshold; uint8_t filt_gain; uint8_t adaptive_gain_control_max;
+    uint8_t adaptive_gain_control_set_point; uint16_t slope_ch1; uint16_t slope_ch2; uint8_t motor_step_delay_time;
+    uint8_t motor_step_angle_size; uint16_t scan_time; uint16_t prf_spl;
+    uint16_t prf_ctl2; uint16_t lockout_time; uint16_t minor_axis_dir;
+    uint8_t major_axis_pan; uint8_t crtl2; uint16_t scan_z; uint8_t ad_threshold_ch1;
+    uint8_t ad_threshold_ch2; uint8_t filt_gain_ch1; uint8_t filt_gain_ch2; uint8_t agc_max_ch1;
+    uint8_t agc_max_ch2; uint8_t agc_set_point_ch1; uint8_t agc_set_point_ch2;
+    uint16_t advanced_slope_ch1; uint16_t advanced_slope_ch2; uint16_t advanced_slope_delay_ch1;
+    uint16_t advanced_slope_delay_ch2;
+
+    ProfilingHeadCommand()
+    {
+        //clear everything 
+        memset(this,0,sizeof(*this));
+    }
+} __attribute__ ((packed));
+
 void Profiling::configure(const ProfilingConfig& config, uint32_t timeout)
 {
-    //some conversions
-    uint16_t left_limit = (((M_PI-config.left_limit.rad)/(M_PI*2.0))*6399.0);
-    uint16_t right_limit = (((M_PI-config.right_limit.rad)/(M_PI*2.0))*6399.0);
-    uint8_t motor_step_angle_size = config.angular_resolution.rad/(M_PI*2.0)*6399.0;
-    uint8_t ad_treshold = config.gain*210;
-    uint8_t filt_gain = config.filt_gain*250;
-    uint32_t freq_chan1_tx = (config.frequency_chan1 * 4294967296) / 32e6;
-    uint32_t freq_chan1_rx = ((config.frequency_chan1 + 455000) * 4294967296) / 32e6;
-    uint32_t freq_chan2_tx = (config.frequency_chan2 * 4294967296) / 32e6;
-    uint32_t freq_chan2_rx = ((config.frequency_chan2 + 455000) * 4294967296) / 32e6;
-    uint16_t slope_ch1 = 114 + ((config.frequency_chan1 - 600000) / 600000) * 36;
-    uint16_t slope_ch2 = 114 + ((config.frequency_chan2 - 600000) / 600000) * 36;
-    uint16_t pulse_length = (config.max_distance + 10) * 25 / 10;
-    uint16_t range_scale = (uint16_t)(config.max_distance * 10.0) & 0x3FFF;
-    uint16_t lockout_time = 542 - ((config.frequency_chan1 - 600000) / 600000) * 271;
-    uint16_t head_control = PRF_FIRST | HASMOT | PRF_MASTER;
-    if(!config.continous)
-        head_control = head_control | PRF_ALT;
-    if(config.select_channel == 2)
-        head_control = head_control | CHAN2;
-    
-    LOG_INFO_S << "Configure Sonar";
-    LOG_DEBUG_S << " right_limit:" << right_limit << " motor_step_angle_size:" << (int)motor_step_angle_size << " initial_gain:"
-                << " lockout_time:" << lockout_time;
-
     //check configuration 
-    if(config.gain < 0.0 || config.gain > 1.0 ||
-       config.angular_resolution.rad < 0 || config.angular_resolution.rad / (0.05625/180.0*M_PI) > 255.0 ||
+    if(config.angular_resolution.rad < 0 || config.angular_resolution.rad / (0.05625/180.0*M_PI) > 255.0 ||
         config.frequency_chan1 < 600000 || config.frequency_chan1 > 1200000 || config.frequency_chan2 < 600000 || config.frequency_chan2 > 1200000 ||
-        config.filt_gain < 0.0 || config.filt_gain > 1.0 || config.select_channel < 1 || config.select_channel > 2 || config.max_distance > 16383.0 || config.max_distance < 0.0)
+        config.select_channel < 1 || config.select_channel > 2 || config.max_distance > 16383.0 || config.max_distance < 0.0)
     {
         throw std::runtime_error("Profiling::Profiling: invalid configuration.");
     }
@@ -80,44 +76,72 @@ void Profiling::configure(const ProfilingConfig& config, uint32_t timeout)
         throw std::runtime_error("Profiling::Profiling: invalid configuration. To many samples per message. Decrease the opening angle or increase the angular resolution.");
     }
 
+    //some conversions
+    uint16_t slope_ch1 = 114 + ((config.frequency_chan1 - 600000) / 600000) * 36;
+    uint16_t slope_ch2 = 114 + ((config.frequency_chan2 - 600000) / 600000) * 36;
+
+    uint16_t head_control = HASMOT | PRF_MASTER;
+    if(!config.continous)
+        head_control |= PRF_ALT;
+    if(config.select_channel == 2)
+        head_control |= CHAN2;
+    if(config.mode == PROFILING_FIRST)
+        head_control |= PRF_FIRST;
+
     speed_of_sound = config.speed_of_sound;
 
+    ProfilingHeadCommand profiling_head_config;
     //generate head data
     profiling_head_config.V3B_params = 0x1D;
+
     profiling_head_config.head_control = head_control;
     profiling_head_config.head_type = 5;
-    profiling_head_config.txn_ch1 = freq_chan1_tx;
-    profiling_head_config.txn_ch2 = freq_chan2_tx;
-    profiling_head_config.rxn_ch1 = freq_chan1_rx;
-    profiling_head_config.rxn_ch2 = freq_chan2_rx;
-    profiling_head_config.pulse_length = pulse_length;
-    profiling_head_config.range_scale = range_scale;
-    profiling_head_config.left_limit = left_limit; 
-    profiling_head_config.right_limit = right_limit;
-    profiling_head_config.ad_threshold = ad_treshold;
-    profiling_head_config.filt_gain = filt_gain;
-    profiling_head_config.adaptive_gain_control_max = 107;
-    profiling_head_config.adaptive_gain_control_set_point = 100;
-    profiling_head_config.slope_ch1 = slope_ch1;
-    profiling_head_config.slope_ch2 = slope_ch2;
-    profiling_head_config.motor_step_delay_time = 25; // 25 to 40
-    profiling_head_config.motor_step_angle_size = motor_step_angle_size;
-    profiling_head_config.scan_time = 30;
+    profiling_head_config.prf_ctl2 = (config.mode == PROFILING_MAX) ? 1 : 0;
+    profiling_head_config.crtl2 = 0;
     profiling_head_config.prf_spl = 0;
-    profiling_head_config.prf_ctl2 = 0;
-    profiling_head_config.lockout_time = lockout_time;
     profiling_head_config.minor_axis_dir = 1600;
     profiling_head_config.major_axis_pan = 1;
-    profiling_head_config.crtl2 = 0;
     profiling_head_config.scan_z = 0;
-    profiling_head_config.ad_threshold_ch1 = 0x32;
-    profiling_head_config.ad_threshold_ch2 = 0x32;
+
+    profiling_head_config.txn_ch1 = (config.frequency_chan1 * 4294967296) / 32e6;
+    profiling_head_config.txn_ch2 = (config.frequency_chan2 * 4294967296) / 32e6;
+    profiling_head_config.rxn_ch1 = ((config.frequency_chan1 + 455000) * 4294967296) / 32e6;
+    profiling_head_config.rxn_ch2 = ((config.frequency_chan2 + 455000) * 4294967296) / 32e6;
+    uint16_t left_limit = (((M_PI-config.left_limit.rad)/(M_PI*2.0))*6399.0);
+    profiling_head_config.left_limit = left_limit; 
+    uint16_t right_limit = (((M_PI-config.right_limit.rad)/(M_PI*2.0))*6399.0);
+    profiling_head_config.right_limit = right_limit;
+    // Value obtained by reverse engineering the communication between the
+    // windows application and the seaking ...
+    profiling_head_config.lockout_time = config.min_distance * 1356;
+    profiling_head_config.pulse_length = 25 + config.max_distance * 25 / 10;
+    profiling_head_config.range_scale = config.max_distance * 10;
+    // Magic number I also got from reverse engineering ... I've picked 13.56
+    // because it is really close to what the windows app does *and* is the same
+    // than the 1356 value for lockout_time which is also a time-to-distance
+    // conversion. Or how to invent correlations where there is probably none.
+    profiling_head_config.scan_time = 13.56 * config.max_distance;
+
+    profiling_head_config.motor_step_delay_time = 25; // 25 to 40
+    uint8_t motor_step_angle_size = config.angular_resolution.rad/(M_PI*2.0)*6399.0;
+    profiling_head_config.motor_step_angle_size = motor_step_angle_size;
+
+    profiling_head_config.ad_threshold = 50;
+    profiling_head_config.ad_threshold_ch1 = 50;
+    profiling_head_config.ad_threshold_ch2 = 50;
+    profiling_head_config.filt_gain = (config.select_channel == 1) ? 1 : 20;
     profiling_head_config.filt_gain_ch1 = 1;
-    profiling_head_config.filt_gain_ch2 = 1;
+    profiling_head_config.filt_gain_ch2 = 20;
+
+    profiling_head_config.adaptive_gain_control_max = 107;
+    profiling_head_config.adaptive_gain_control_set_point = 100;
     profiling_head_config.agc_max_ch1 = 0x6b;
     profiling_head_config.agc_max_ch2 = 0x6b;
     profiling_head_config.agc_set_point_ch1 = 0x64;
     profiling_head_config.agc_set_point_ch2 = 0x64;
+
+    profiling_head_config.slope_ch1 = slope_ch1;
+    profiling_head_config.slope_ch2 = slope_ch2;
     profiling_head_config.advanced_slope_ch1 = 110;
     profiling_head_config.advanced_slope_ch2 = 150;
     profiling_head_config.advanced_slope_delay_ch1 = 0;
@@ -125,6 +149,60 @@ void Profiling::configure(const ProfilingConfig& config, uint32_t timeout)
     
     HeadCommand* head_config = reinterpret_cast<HeadCommand*>(&profiling_head_config);
     writeHeadCommand(*head_config, timeout);
+}
+
+// Change acquisition parameters without resetting the head (fast parameter
+// change)
+//
+// This is purely coming from reverse engineering
+//
+// The 'magic' fields are the fields for which I had no idea what to do
+struct ProfilingAcquisitionConfigMessage
+{
+    // Always 30 for this message
+    uint8_t V3B_params;
+    // A/D thresholds for channels 1 and 2
+    uint8_t ad_threshold[2];
+    // "filt_gain" (no idea what the hell it is). I leave it to the default
+    // values, as even the windows application does not touch it
+    uint8_t filt_gain[2];
+    // The actual gain. Note that this is THE value that - it seems - cannot be
+    // changed in the head profiling configuration structure
+    uint8_t gain[2];
+    // Wild guess. Left at default values of 189
+    uint8_t agc_setpoint[2];
+    // Wild guess. Left at default values of 110 and 150
+    uint16_t slope[2];
+    // Wild guess. Left at default values of 0
+    uint16_t advanced_slope_delay[2];
+} __attribute__ ((packed));
+
+void Profiling::configureAcquisition(ProfilingAcquisitionConfig const& config, uint32_t timeout)
+{
+    if (has_pending_data)
+        throw std::runtime_error("requestData() called and the corresponding receiveData() has not been called");
+
+    ProfilingAcquisitionConfigMessage msg;
+    msg.V3B_params = 30;
+    msg.ad_threshold[0] = msg.ad_threshold[1] = config.ad_threshold * 255;
+    msg.filt_gain[0] = 1;
+    msg.filt_gain[1] = 20;
+    msg.gain[0] = config.gain * 255;
+    msg.gain[1] = config.gain * 255;
+    msg.agc_setpoint[0] = msg.agc_setpoint[1] = 189;
+    msg.slope[0] = 110;
+    msg.slope[1] = 150;
+    msg.advanced_slope_delay[0] = 0;
+    msg.advanced_slope_delay[1] = 0;
+
+    std::vector<uint8_t> packet =
+        SeaNetPacket::createPaket(device_type,
+                mtHeadCommand,
+                (uint8_t*)&msg,
+                sizeof(msg));
+
+    LOG_DEBUG_S <<"Sent mtHeadCommand packet" ;
+    writePacket(&packet[0],packet.size(),timeout);
 }
 
 void Profiling::decodeScan(base::samples::LaserScan& scan)

--- a/src/SeaNetProfiling.hpp
+++ b/src/SeaNetProfiling.hpp
@@ -12,38 +12,17 @@ namespace aggregator
 
 namespace sea_net
 {
-    struct ProfilingHeadCommand
-    {
-        uint8_t V3B_params; uint16_t head_control; uint8_t head_type;
-        uint32_t txn_ch1; uint32_t txn_ch2; uint32_t rxn_ch1; uint32_t rxn_ch2;
-        uint16_t pulse_length; uint16_t range_scale; uint16_t left_limit;
-        uint16_t right_limit; uint8_t ad_threshold; uint8_t filt_gain; uint8_t adaptive_gain_control_max;
-        uint8_t adaptive_gain_control_set_point; uint16_t slope_ch1; uint16_t slope_ch2; uint8_t motor_step_delay_time;
-        uint8_t motor_step_angle_size; uint16_t scan_time; uint16_t prf_spl;
-        uint16_t prf_ctl2; uint16_t lockout_time; uint16_t minor_axis_dir;
-        uint8_t major_axis_pan; uint8_t crtl2; uint16_t scan_z; uint8_t ad_threshold_ch1;
-        uint8_t ad_threshold_ch2; uint8_t filt_gain_ch1; uint8_t filt_gain_ch2; uint8_t agc_max_ch1;
-        uint8_t agc_max_ch2; uint8_t agc_set_point_ch1; uint8_t agc_set_point_ch2;
-        uint16_t advanced_slope_ch1; uint16_t advanced_slope_ch2; uint16_t advanced_slope_delay_ch1;
-        uint16_t advanced_slope_delay_ch2;
-
-        ProfilingHeadCommand()
-        {
-            //clear everything 
-            memset(this,0,sizeof(*this));
-        }
-    } __attribute__ ((packed)) __attribute__((__may_alias__));
-    
     class Profiling : public SeaNet
     {
     public:
         Profiling();
         ~Profiling();
         void configure(const ProfilingConfig &config, uint32_t timeout);
+        void configureAcquisition(const ProfilingAcquisitionConfig &config, uint32_t timeout);
         void decodeScan(base::samples::LaserScan &scan);
+
     private:
         aggregator::TimestampEstimator* timestamp_estimator;
-        ProfilingHeadCommand profiling_head_config;
         double speed_of_sound;
     };
 };

--- a/src/SeaNetTypes.hpp
+++ b/src/SeaNetTypes.hpp
@@ -35,42 +35,78 @@ namespace sea_net
         mtSendPreferenceData
     };
 
+    /** Acquisition mode for the profiling sonar
+     *
+     * This governs what information the sonar returns
+     */
+    enum PROFILING_MODE
+    {
+        /** Return the first echo that is above the ad_threshold parameter
+         *
+         * This is the fastest mode (as the head can continue after the first
+         * echo), but is obviously dependent on choosing both a good gain and
+         * threshold
+         */
+        PROFILING_FIRST,
+        PROFILING_NORMAL,
+        /** Return the highest echo */
+        PROFILING_MAX
+    };
+
+    /** Complete configuration of the SeaKing
+     *
+     * Note that ProfilingAcquisitionConfig allows to set a subset of the
+     * parameters in a much faster way
+     */
     struct ProfilingConfig
     {
+        PROFILING_MODE mode;
+
         base::Angle left_limit;
         base::Angle right_limit;
         base::Angle angular_resolution; 
 
+        /** Which channel to use */
         unsigned int select_channel;
         unsigned int frequency_chan1;
         unsigned int frequency_chan2;
         
+        /** Maximum distance. A higher distance usually means longer acquisition
+         * times as the sonar has to wait longer for an echo before going on
+         */
         double max_distance;
+        /** Minimum distance under which echoes will be ignored (in m) */
         double min_distance;
+        /** The speed of sound (by default 1500 m/s) used to convert
+         * configuration parameters in meters to device parameters that are
+         * usually in seconds
+         */
         double speed_of_sound;
-        double gain;
-        double filt_gain;
         
+        /** Whether scanning should go always in the same direction or
+         * "ping-pong". When scanning a small segment, a non-continuous mode is
+         * recommended
+         */
         bool continous;
         
         ProfilingConfig() : 
+            mode(PROFILING_FIRST),
             left_limit(base::Angle::fromRad(M_PI)),
             right_limit(base::Angle::fromRad(-M_PI)),
             angular_resolution(base::Angle::fromRad(5.0/180.0*M_PI)),
-            select_channel(1),
+            select_channel(2),
             frequency_chan1(600000),
             frequency_chan2(1200000),
             max_distance(15.0),
             min_distance(1.0),
             speed_of_sound(1500.0),
-            gain(0.2),
-            filt_gain(0.01),
             continous(false)
         {};
       
         bool operator==(const ProfilingConfig &other) const
         {
-            return (other.left_limit == left_limit &&
+            return (other.mode == mode &&
+                    other.left_limit == left_limit &&
                     other.right_limit == right_limit &&
                     other.angular_resolution == angular_resolution &&
                     other.select_channel == select_channel &&
@@ -79,14 +115,37 @@ namespace sea_net
                     other.max_distance == max_distance && 
                     other.min_distance == min_distance && 
                     other.speed_of_sound== speed_of_sound &&
-                    other.gain == gain &&
-                    other.filt_gain == filt_gain);
+                    other.continous == continous);
         };
         
         bool operator!=(const ProfilingConfig &other) const
         {
             return !(other == *this);
         };
+    };
+
+    /** Smaller configuration structure for acquisition parameters that can be
+     * changed live on the Tritech seaking.
+     *
+     * Changing these parameters is almost instantaneous, unlike using the
+     * ProfilingConfig which involves resetting the whole device
+     */
+    struct ProfilingAcquisitionConfig
+    {
+        /** The acquisition gain in [0, 1]. Documentation recommends to start
+         * with 40% (0.4)
+         */
+        double gain;
+        /** Signal under this threshold will be ignored by the sonar. The
+         * documentation recommends to stick with 0.2
+         *
+         * The value is in percent, i.e. [0, 1]
+         */
+        double ad_threshold;
+
+        ProfilingAcquisitionConfig()
+            : gain(0.4)
+            , ad_threshold(0.2) {}
     };
 
     //some values are not working for the micron dst like lock_out time

--- a/src/SeaNetTypesInternal.cpp
+++ b/src/SeaNetTypesInternal.cpp
@@ -31,7 +31,7 @@ int SeaNetPacket::isValidPacket(uint8_t const *buffer, size_t buffer_size)
     //this len is the size of the packet from byte 6 onwards
     size_t len;
     size_t hexlen = 0;
-    sscanf((const char*)&buffer[1],"%4X",&hexlen);
+    sscanf((const char*)&buffer[1],"%4lX",&hexlen);
     len = (buffer[5] | (buffer[6]<<8 ));
 
     //check if both lengths are equal (simple check)
@@ -147,7 +147,7 @@ std::vector<uint8_t> SeaNetPacket::createPaket(DeviceType device_type,
     //in the packet size encoded into the package
     //Header
     packet[0] = PACKET_START;
-    sprintf((char*)&packet[1],"%04X",size2);
+    sprintf((char*)&packet[1],"%04lX",size2);
 
     packet[5] = (size2) & 255;
     packet[6] = ((size2)>>8) & 255;

--- a/src/SeaNetTypesInternal.cpp
+++ b/src/SeaNetTypesInternal.cpp
@@ -59,8 +59,7 @@ int SeaNetPacket::isValidPacket(uint8_t const *buffer, size_t buffer_size)
         switch(type)
         {
         case mtHeadCommand:
-            if(len == 82)
-                return len;
+            return len;
             break;
         case mtSendData:
             if(len == 18)

--- a/src/SeaNetTypesInternal.cpp
+++ b/src/SeaNetTypesInternal.cpp
@@ -48,11 +48,11 @@ int SeaNetPacket::isValidPacket(uint8_t const *buffer, size_t buffer_size)
     if(len > buffer_size)
         return 0;               //packet is to small wait for more data
 
+    //DeviceType device_type = (DeviceType) buffer[8];
+    PacketType type = (PacketType) buffer[10];
     //checking for the end of the packet 
     if (buffer[len-1] == PACKET_END) 
     {
-        //DeviceType device_type = (DeviceType) buffer[8];
-        PacketType type = (PacketType) buffer[10];
         LOG_DEBUG_S << "Found packet of type "<< type << " and size "<< len ;
 
         //check packet size
@@ -127,7 +127,7 @@ int SeaNetPacket::isValidPacket(uint8_t const *buffer, size_t buffer_size)
                    << len ;
         return -1;
     }
-    LOG_WARN_S << "Corrupted packet: No Message end was found" ;
+    LOG_WARN_S << "Corrupted packet (possibly type " << type << "): no message end was found, packet size " << len;
     return -1; 
 }
 

--- a/src/SeaNetTypesInternal.cpp
+++ b/src/SeaNetTypesInternal.cpp
@@ -238,7 +238,7 @@ void SeaNetPacket::getRawData(const uint8_t * &buffer,size_t &size)const
     size = this->size;
 }
 
-void SeaNetPacket::decodeAliveData(AliveData &data)
+void SeaNetPacket::decodeAliveData(AliveData &data) const
 {
     if(getPacketType() != mtAlive)
         throw std::runtime_error("Cannot decode AliveData. Wrong packet type is buffered.");
@@ -251,7 +251,7 @@ void SeaNetPacket::decodeAliveData(AliveData &data)
     data.config_send = packet[20]&128;
 }
 
-void SeaNetPacket::decodeHeadData(ImagingHeadData &data)
+void SeaNetPacket::decodeHeadData(ImagingHeadData &data) const
 {
     if(getPacketType() != mtHeadData)
         throw std::runtime_error("Cannot decode mtHeadData. Wrong packet type is buffered.");
@@ -283,7 +283,7 @@ void SeaNetPacket::decodeHeadData(ImagingHeadData &data)
     data.scan_data      = &packet[44];
 }
 
-void SeaNetPacket::decodeHeadData(ProfilingHeadData& data)
+void SeaNetPacket::decodeHeadData(ProfilingHeadData& data) const
 {
     if(getPacketType() != mtHeadData)
         throw std::runtime_error("Cannot decode mtHeadData. Wrong packet type is buffered.");
@@ -313,7 +313,7 @@ void SeaNetPacket::decodeHeadData(ProfilingHeadData& data)
     data.scan_data      = &packet[40];
 }
 
-void SeaNetPacket::decodeAuxData(std::vector<uint8_t> &aux_data)
+void SeaNetPacket::decodeAuxData(std::vector<uint8_t> &aux_data) const
 {
     if(getPacketType() != mtAuxData)
         throw std::runtime_error("SeaNet: Wrong packet is stored in the buffer!");
@@ -326,7 +326,7 @@ void SeaNetPacket::decodeAuxData(std::vector<uint8_t> &aux_data)
     memcpy(&aux_data[0],&packet[15],aux_size);
 }
 
-void SeaNetPacket::decodeVersionData(VersionData &version)
+void SeaNetPacket::decodeVersionData(VersionData &version) const
 {
     if(getPacketType() != mtVersionData)
         throw std::runtime_error("SeaNet: Wrong packet is stored in the buffer!");
@@ -339,7 +339,7 @@ void SeaNetPacket::decodeVersionData(VersionData &version)
     version.nodeID = packet[23];
 }
 
-void SeaNetPacket::decodeBBUserData(BBUserData &data)
+void SeaNetPacket::decodeBBUserData(BBUserData &data) const
 {
     if(getPacketType() != mtBBUserData)
         throw std::runtime_error("SeaNet: Wrong packet is stored in the buffer!");

--- a/src/SeaNetTypesInternal.cpp
+++ b/src/SeaNetTypesInternal.cpp
@@ -344,5 +344,5 @@ void SeaNetPacket::decodeBBUserData(BBUserData &data)
 {
     if(getPacketType() != mtBBUserData)
         throw std::runtime_error("SeaNet: Wrong packet is stored in the buffer!");
-    data.full_dublex = !packet[146];
+    data.full_duplex = !packet[146];
 }

--- a/src/SeaNetTypesInternal.hpp
+++ b/src/SeaNetTypesInternal.hpp
@@ -97,9 +97,9 @@ namespace sea_net
 
     struct BBUserData
     {
-        bool full_dublex;
+        bool full_duplex;
         BBUserData():
-            full_dublex(0){};
+            full_duplex(0){};
     };
 
     class SeaNetPacket

--- a/src/SeaNetTypesInternal.hpp
+++ b/src/SeaNetTypesInternal.hpp
@@ -2,7 +2,7 @@
 #define _SEANET_TYPES_INTERNAL_H_
 
 #include "SeaNetTypes.hpp"
-#define SEA_NET_MAX_PACKET_SIZE 1545 // mtHeadData is the biggest package 
+#define SEA_NET_MAX_PACKET_SIZE 4096 // mtHeadData is the biggest package 
 
 namespace sea_net
 {

--- a/src/SeaNetTypesInternal.hpp
+++ b/src/SeaNetTypesInternal.hpp
@@ -126,12 +126,12 @@ namespace sea_net
 
             void getRawData(const uint8_t * &buffer,size_t &size)const;
 
-            void decodeAliveData(AliveData &data);
-            void decodeHeadData(ImagingHeadData &data);
-            void decodeHeadData(ProfilingHeadData &data);
-            void decodeAuxData(std::vector<uint8_t> &aux_data);
-            void decodeVersionData(VersionData &version);
-            void decodeBBUserData(BBUserData &data);
+            void decodeAliveData(AliveData &data) const;
+            void decodeHeadData(ImagingHeadData &data) const;
+            void decodeHeadData(ProfilingHeadData &data) const;
+            void decodeAuxData(std::vector<uint8_t> &aux_data) const;
+            void decodeVersionData(VersionData &version) const;
+            void decodeBBUserData(BBUserData &data) const;
 
         private:
         //we do not use a std::vector because this would introduce

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,4 @@
-add_definitions(-g)
-rock_testsuite(test_detector DEPS sonar_tritech SOURCES test_micron.cpp)
+rock_testsuite(test_detector
+    DEPS sonar_tritech
+    SOURCES suite.cpp test_micron.cpp)
 

--- a/test/suite.cpp
+++ b/test/suite.cpp
@@ -1,0 +1,6 @@
+// Do NOT add anything to this file
+// This header from boost takes ages to compile, so we make sure it is compiled
+// only once (here)
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>
+

--- a/test/test_micron.cpp
+++ b/test/test_micron.cpp
@@ -1,11 +1,7 @@
+#include <boost/test/unit_test.hpp>
+
 #include "../src/SeaNetMicron.hpp"
 
-#define BOOST_TEST_DYN_LINK
-#define BOOST_TEST_MAIN
-#define BOOST_TEST_MODULE "MicronDriver"
-#define BOOST_AUTO_TEST_MAIN
-#include <boost/test/auto_unit_test.hpp>
-#include <boost/test/unit_test.hpp>
 
 #include <iodrivers_base/Exceptions.hpp>
 #include <iostream>

--- a/test/test_micron.cpp
+++ b/test/test_micron.cpp
@@ -12,7 +12,7 @@ BOOST_AUTO_TEST_CASE(micron)
     sea_net::Micron micron;
 
     //check opening of a wrong port
-    BOOST_CHECK_THROW(micron.openSerial("/dev/ttyUSB1"),std::runtime_error);
+    BOOST_CHECK_THROW(micron.openSerial("/dev/ttyUSB1", 115200),std::runtime_error);
 
     //check opening 
     micron.openSerial("/dev/ttyUSB0",115200);
@@ -24,7 +24,6 @@ BOOST_AUTO_TEST_CASE(micron)
     sea_net::MicronConfig conf;
     base::samples::SonarBeam sonar_beam;
     conf.max_distance = 4;
-    micron.start();
     
     conf.angular_resolution = base::Angle::fromDeg(1.0);
     micron.configure(conf,10000);

--- a/test/test_micron.cpp
+++ b/test/test_micron.cpp
@@ -31,7 +31,8 @@ BOOST_AUTO_TEST_CASE(micron)
     double start_angle = -99;
     for(int i=0;i<10;++i)
     {
-        micron.waitForPacket(sea_net::mtHeadData,400);
+        micron.requestData();
+        micron.receiveData(1000);
         micron.decodeSonarBeam(sonar_beam);
         std::cout << "bearing[deg]: " << sonar_beam.bearing.rad /M_PI*180 << std::endl;;
         if(start_angle == -99)
@@ -44,7 +45,8 @@ BOOST_AUTO_TEST_CASE(micron)
     std::cout <<" TEST 360° Degree Modus with 5° Steps" << std::endl;
     for(int i=0;i<10;++i)
     {
-        micron.waitForPacket(sea_net::mtHeadData,200);
+        micron.requestData();
+        micron.receiveData(1000);
         micron.decodeSonarBeam(sonar_beam);
         std::cout << "bearing[deg]: " << sonar_beam.bearing.rad /M_PI*180 << std::endl;
     }
@@ -55,7 +57,8 @@ BOOST_AUTO_TEST_CASE(micron)
     std::cout <<" TEST 360° Degree Modus with 10° Steps" << std::endl;
     for(int i=0;i<10;++i)
     {
-        micron.waitForPacket(sea_net::mtHeadData,400);
+        micron.requestData();
+        micron.receiveData(1000);
         micron.decodeSonarBeam(sonar_beam);
         std::cout << "bearing[deg]: " << sonar_beam.bearing.rad /M_PI*180 << std::endl;;
     }
@@ -71,7 +74,8 @@ BOOST_AUTO_TEST_CASE(micron)
     std::cout <<" TEST LeftRight +-15° Modus with 5° Steps" << std::endl;
     for(int i=0;i<10;++i)
     {
-        micron.waitForPacket(sea_net::mtHeadData,200);
+        micron.requestData();
+        micron.receiveData(1000);
         micron.decodeSonarBeam(sonar_beam);
         std::cout << "bearing[deg]: " << sonar_beam.bearing.rad /M_PI*180 << std::endl;;
     }
@@ -85,7 +89,8 @@ BOOST_AUTO_TEST_CASE(micron)
     std::cout <<" TEST LeftRight +15 +30° Modus with 5° Steps" << std::endl;
     for(int i=0;i<10;++i)
     {
-        micron.waitForPacket(sea_net::mtHeadData,200);
+        micron.requestData();
+        micron.receiveData(1000);
         micron.decodeSonarBeam(sonar_beam);
         std::cout << "bearing[deg]: " << sonar_beam.bearing.rad /M_PI*180 << std::endl;;
     }
@@ -99,7 +104,8 @@ BOOST_AUTO_TEST_CASE(micron)
     std::cout <<" TEST LeftRight -15 -30° Modus with 5° Steps" << std::endl;
     for(int i=0;i<10;++i)
     {
-        micron.waitForPacket(sea_net::mtHeadData,200);
+        micron.requestData();
+        micron.receiveData(1000);
         micron.decodeSonarBeam(sonar_beam);
         std::cout << "bearing[deg]: " << sonar_beam.bearing.rad /M_PI*180 << std::endl;;
     }


### PR DESCRIPTION
The SeaNet driver has been written to emulate a continuous scanning device while all the tritech
devices are polling-based. This led to a lot of state tracking, and makes the timeout specifications
close to useless (as the timeout for "read a scan" will actually be the timeout for "read a scan and
send a new command in some cases but not all ...).

There is very little complexity involved in pushing the duty of requesting scans to the class user (see the related pull request on the orogen component), and it simplifies the logic of the SeaNet class quite a lot.