### PR TITLE
Handle MOTERR flag

### DIFF
--- a/src/SeaNetMicron.cpp
+++ b/src/SeaNetMicron.cpp
@@ -32,6 +32,11 @@ void Micron::decodeSonar(base::samples::Sonar &sonar)
     ImagingHeadData data;
     sea_net_packet.decodeHeadData(data);
 
+    // If the transducer head bearing is getting confused about its position, the sonar image will be rotated.
+    // This is noticed by MOTERR flag. In this case, throw this exception.
+    if (((data.head_status >> 1) & 1))
+        throw std::runtime_error("Motor head lost synchronization.");
+
     //check if the configuration is ok
     //be careful some values cannot be configured for the micron dst like SCANRIGHT (always == 1)
     //some other values are dynamically by the device like MOTOFF


### PR DESCRIPTION
Micron packet data (mtHeadData) contains a bit 'MotErr' which means the motor head rotator lost synchronization. This causes a rotated sonar image.

It is related with https://github.com/rock-drivers/drivers-sonar_tritech/issues/5.